### PR TITLE
Add ML breakout prediction

### DIFF
--- a/test_app.py
+++ b/test_app.py
@@ -1,0 +1,17 @@
+import pandas as pd
+from app import add_indicators
+
+def test_add_indicators():
+    n = 20
+    df = pd.DataFrame({
+        'timestamp': range(n),
+        'open': range(1, n+1),
+        'high': range(2, n+2),
+        'low': [x - 0.5 for x in range(1, n+1)],
+        'close': [x + 0.5 for x in range(1, n+1)],
+        'volume': [100]*n,
+    })
+    out = add_indicators(df.copy())
+    assert 'vwap' in out.columns
+    assert 'atr' in out.columns
+    assert not out[['vwap', 'atr']].isna().any().any()


### PR DESCRIPTION
## Summary
- implement breakout predictor with RandomForest
- compute indicators such as VWAP, ATR, RSI, and MACD
- generate simple labels for TP/SL outcomes
- add pytest unit test for indicator calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843502be260832cab11e667e0ec5344